### PR TITLE
Allow encrypt/decrypt toggle on existing documents

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -382,7 +382,8 @@ export function DocumentEditor() {
 
   const existingFileId = data && data.file_id;
   const existingFileEncrypted = isEncryptedFileId(existingFileId, id);
-  const showEncryptToggle = isNew;
+
+  const isExistingEncrypted = !isNew && unlocked;
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">
@@ -422,30 +423,38 @@ export function DocumentEditor() {
           className="mb-6"
         />
 
-        {showEncryptToggle && (
-          <div style={{ colorScheme: 'light' }} className="mb-6 p-4 border rounded-lg bg-gray-50 text-black">
-            <label className="flex items-center space-x-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={encryptEnabled}
-                onChange={(e) => setEncryptEnabled(e.target.checked)}
-              />
-              <span className="font-medium">🔒 Encrypt with a password</span>
-            </label>
-            {encryptEnabled && (
-              <div className="mt-3 space-y-2">
+        <div style={{ colorScheme: 'light' }} className={
+          encryptEnabled
+            ? "mb-6 p-4 border rounded-lg bg-gray-50 text-black"
+            : "mb-6 p-4 border rounded-lg bg-white text-black"
+        }>
+          <label className="flex items-center space-x-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={encryptEnabled}
+              onChange={(e) => setEncryptEnabled(e.target.checked)}
+            />
+            <span className="font-medium">
+              {isExistingEncrypted ? "🔒 Keep encrypted with password" : "🔒 Encrypt with a password"}
+            </span>
+          </label>
+          {encryptEnabled && (
+            <div className="mt-3 space-y-2">
+              {!isExistingEncrypted && (
                 <p className="text-xs text-gray-600">
                   Text and attachment will be encrypted in your browser (AES-256-GCM).
                   The password is never sent to the server. If you lose it, the document
                   is unrecoverable.
                 </p>
-                <input
-                  type="password"
-                  placeholder="Password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="w-full px-3 py-2 border rounded text-black"
-                />
+              )}
+              <input
+                type="password"
+                placeholder="Password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full px-3 py-2 border rounded text-black"
+              />
+              {!isExistingEncrypted && (
                 <input
                   type="password"
                   placeholder="Confirm password"
@@ -453,14 +462,19 @@ export function DocumentEditor() {
                   onChange={(e) => setPasswordConfirm(e.target.value)}
                   className="w-full px-3 py-2 border rounded text-black"
                 />
-              </div>
-            )}
-          </div>
-        )}
+              )}
+            </div>
+          )}
+          {isExistingEncrypted && !encryptEnabled && (
+            <p className="mt-2 text-xs text-amber-700">
+              ⚠️ Encryption is off. Saving will store this document as plaintext.
+            </p>
+          )}
+        </div>
 
-        {!isNew && unlocked && (
+        {isExistingEncrypted && encryptEnabled && (
           <div style={{ colorScheme: 'light' }} className="mb-6 p-3 border rounded-lg bg-green-50 text-sm text-gray-700">
-            This document is encrypted. Saving will re-encrypt with the same password.
+            This document is encrypted. Uncheck the toggle above to save it as plaintext, or keep it checked to re-encrypt.
           </div>
         )}
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -447,12 +447,16 @@ export function DocumentEditor() {
                   is unrecoverable.
                 </p>
               )}
+              {isExistingEncrypted && (
+                <p className="text-xs text-gray-500">(read-only, from unlock)</p>
+              )}
               <input
                 type="password"
                 placeholder="Password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="w-full px-3 py-2 border rounded text-black"
+                readOnly={isExistingEncrypted}
+                className={`w-full px-3 py-2 border rounded text-black ${isExistingEncrypted ? 'bg-gray-100 cursor-not-allowed' : ''}`}
               />
               {!isExistingEncrypted && (
                 <input
@@ -465,9 +469,16 @@ export function DocumentEditor() {
               )}
             </div>
           )}
-          {isExistingEncrypted && !encryptEnabled && (
+          {isExistingEncrypted && !encryptEnabled && !existingFileEncrypted && (
             <p className="mt-2 text-xs text-amber-700">
               ⚠️ Encryption is off. Saving will store this document as plaintext.
+            </p>
+          )}
+          {existingFileEncrypted && !encryptEnabled && (
+            <p className="mt-2 text-xs text-red-700">
+              ⚠️ Encryption is off but this document has an encrypted attachment.
+              {!file && " The encrypted file will remain on the server but will be unrecoverable without the original password."}
+              {file && " Uploading a new file will replace it."}
             </p>
           )}
         </div>


### PR DESCRIPTION
## Summary

- Encrypt/decrypt password toggle is now available for **all** documents, not only new ones (`frontend/src/App.jsx`). Previously the toggle was hidden after creation, making it impossible to add encryption to an existing plaintext doc or to remove it from an encrypted one.
- For documents that were unlocked (`isExistingEncrypted`), the password input is rendered `readOnly` with a gray background and a "(read-only, from unlock)" hint, so the user cannot accidentally change the password and brick the document at save time.
- When the user turns the toggle off on a doc whose attachment is still encrypted (`existingFileEncrypted && !encryptEnabled`), a red warning explains that the encrypted attachment will be orphaned on the server (unrecoverable without the original password) unless a new file is uploaded.

## Commits

- `33afcd5` — Make encrypt/decrypt toggle available for all documents (new and existing)
- `0765d5e` — fix: prevent accidental password change on unlocked encrypted docs, warn on orphaned encrypted attachment

## Test plan

- [ ] Open an existing **plaintext** document → toggle visible and unchecked; checking it enables password + confirm fields; save re-uploads encrypted.
- [ ] Open an existing **encrypted** document, unlock it → toggle visible and pre-checked; password field is pre-filled and read-only (gray, "(read-only, from unlock)" hint); save re-encrypts with same password.
- [ ] Open an existing encrypted document with **encrypted attachment**, unlock, then uncheck the toggle without uploading a new file → red warning appears stating the encrypted attachment will be orphaned.
- [ ] Same as above but upload a replacement file → red warning text adapts ("Uploading a new file will replace it.").
- [ ] Create a **new** document → toggle visible and unchecked; behavior identical to before the change (password + confirm required, mismatch alert on submit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)