### PR TITLE
fix: sync attachment crypto state with document body (#12, supersedes #11)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -350,6 +350,26 @@ export function DocumentEditor() {
         if (file) payloadFile = await encryptFile(password, file);
       }
 
+      // Issue #12: keep doc body and attachment in lockstep when the user
+      // toggles encryption on an existing doc without uploading a new file.
+      if (existingFileId && !file && existingFileEncrypted !== encryptEnabled) {
+        const resp = await fetch(`${backendUrl}/documents/download/${existingFileId}`);
+        if (!resp.ok) throw new Error('Failed to fetch existing attachment for crypto sync');
+        const blob = await resp.blob();
+        if (existingFileEncrypted) {
+          const buf = new Uint8Array(await blob.arrayBuffer());
+          const { name, bytes } = await decryptFile(password, buf);
+          payloadFile = new File([bytes], name, { type: 'application/octet-stream' });
+        } else {
+          const namePrefix = `${id}_`;
+          const originalName = existingFileId.startsWith(namePrefix)
+            ? existingFileId.slice(namePrefix.length)
+            : existingFileId;
+          const plainFile = new File([blob], originalName, { type: blob.type || 'application/octet-stream' });
+          payloadFile = await encryptFile(password, plainFile);
+        }
+      }
+
       const url = isNew ? `${backendUrl}/documents` : `${backendUrl}/documents/${id}`;
       const method = isNew ? 'POST' : 'PUT';
       setEditing(false);
@@ -469,16 +489,10 @@ export function DocumentEditor() {
               )}
             </div>
           )}
-          {isExistingEncrypted && !encryptEnabled && !existingFileEncrypted && (
+          {isExistingEncrypted && !encryptEnabled && (
             <p className="mt-2 text-xs text-amber-700">
-              ⚠️ Encryption is off. Saving will store this document as plaintext.
-            </p>
-          )}
-          {existingFileEncrypted && !encryptEnabled && (
-            <p className="mt-2 text-xs text-red-700">
-              ⚠️ Encryption is off but this document has an encrypted attachment.
-              {!file && " The encrypted file will remain on the server but will be unrecoverable without the original password."}
-              {file && " Uploading a new file will replace it."}
+              ⚠️ Encryption is off. Saving will store the document and any
+              existing attachment as plaintext.
             </p>
           )}
         </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -382,7 +382,8 @@ export function DocumentEditor() {
 
   const existingFileId = data && data.file_id;
   const existingFileEncrypted = isEncryptedFileId(existingFileId, id);
-  const showEncryptToggle = isNew;
+
+  const isExistingEncrypted = !isNew && unlocked;
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">
@@ -422,30 +423,38 @@ export function DocumentEditor() {
           className="mb-6"
         />
 
-        {showEncryptToggle && (
-          <div style={{ colorScheme: 'light' }} className="mb-6 p-4 border rounded-lg bg-gray-50 text-black">
-            <label className="flex items-center space-x-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={encryptEnabled}
-                onChange={(e) => setEncryptEnabled(e.target.checked)}
-              />
-              <span className="font-medium">🔒 Encrypt with a password</span>
-            </label>
-            {encryptEnabled && (
-              <div className="mt-3 space-y-2">
+        <div style={{ colorScheme: 'light' }} className={
+          encryptEnabled
+            ? "mb-6 p-4 border rounded-lg bg-gray-50 text-black"
+            : "mb-6 p-4 border rounded-lg bg-white text-black"
+        }>
+          <label className="flex items-center space-x-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={encryptEnabled}
+              onChange={(e) => setEncryptEnabled(e.target.checked)}
+            />
+            <span className="font-medium">
+              {isExistingEncrypted ? "🔒 Keep encrypted with password" : "🔒 Encrypt with a password"}
+            </span>
+          </label>
+          {encryptEnabled && (
+            <div className="mt-3 space-y-2">
+              {!isExistingEncrypted && (
                 <p className="text-xs text-gray-600">
                   Text and attachment will be encrypted in your browser (AES-256-GCM).
                   The password is never sent to the server. If you lose it, the document
                   is unrecoverable.
                 </p>
-                <input
-                  type="password"
-                  placeholder="Password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="w-full px-3 py-2 border rounded text-black"
-                />
+              )}
+              <input
+                type="password"
+                placeholder="Password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full px-3 py-2 border rounded text-black"
+              />
+              {!isExistingEncrypted && (
                 <input
                   type="password"
                   placeholder="Confirm password"
@@ -453,14 +462,19 @@ export function DocumentEditor() {
                   onChange={(e) => setPasswordConfirm(e.target.value)}
                   className="w-full px-3 py-2 border rounded text-black"
                 />
-              </div>
-            )}
-          </div>
-        )}
+              )}
+            </div>
+          )}
+          {isExistingEncrypted && !encryptEnabled && (
+            <p className="mt-2 text-xs text-amber-700">
+              ⚠️ Encryption is off. Saving will store this document as plaintext.
+            </p>
+          )}
+        </div>
 
-        {!isNew && unlocked && (
+        {isExistingEncrypted && encryptEnabled && (
           <div style={{ colorScheme: 'light' }} className="mb-6 p-3 border rounded-lg bg-green-50 text-sm text-gray-700">
-            This document is encrypted. Saving will re-encrypt with the same password.
+            This document is encrypted. Uncheck the toggle above to save it as plaintext, or keep it checked to re-encrypt.
           </div>
         )}
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -447,12 +447,16 @@ export function DocumentEditor() {
                   is unrecoverable.
                 </p>
               )}
+              {isExistingEncrypted && (
+                <p className="text-xs text-gray-500">(read-only, from unlock)</p>
+              )}
               <input
                 type="password"
                 placeholder="Password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="w-full px-3 py-2 border rounded text-black"
+                readOnly={isExistingEncrypted}
+                className={`w-full px-3 py-2 border rounded text-black ${isExistingEncrypted ? 'bg-gray-100 cursor-not-allowed' : ''}`}
               />
               {!isExistingEncrypted && (
                 <input
@@ -465,9 +469,16 @@ export function DocumentEditor() {
               )}
             </div>
           )}
-          {isExistingEncrypted && !encryptEnabled && (
+          {isExistingEncrypted && !encryptEnabled && !existingFileEncrypted && (
             <p className="mt-2 text-xs text-amber-700">
               ⚠️ Encryption is off. Saving will store this document as plaintext.
+            </p>
+          )}
+          {existingFileEncrypted && !encryptEnabled && (
+            <p className="mt-2 text-xs text-red-700">
+              ⚠️ Encryption is off but this document has an encrypted attachment.
+              {!file && " The encrypted file will remain on the server but will be unrecoverable without the original password."}
+              {file && " Uploading a new file will replace it."}
             </p>
           )}
         </div>

--- a/frontend/src/test/App.test.jsx
+++ b/frontend/src/test/App.test.jsx
@@ -654,6 +654,118 @@ describe('Encryption UI', () => {
     expect(screen.queryByText(/very private/i)).not.toBeInTheDocument();
   });
 
+  it('Issue #12: re-uploads decrypted attachment when toggling encryption off on existing doc', async () => {
+    const user = userEvent.setup();
+    const { encryptText, encryptFile } = await import('../crypto');
+
+    const docId = 'sync1234-aaaa-bbbb-cccc-000000000000';
+    const password = 'sync-pw';
+    const envelope = await encryptText(password, 'secret body');
+
+    const plainBytes = new Uint8Array([10, 20, 30, 40, 50]);
+    const plainFile = new File([plainBytes], 'data.bin');
+    const encWire = new Uint8Array(await (await encryptFile(password, plainFile)).arrayBuffer());
+
+    const fileId = `${docId}_dmencblob`;
+    const docResponse = { id: docId, title: 't', content: envelope, file_id: fileId };
+
+    global.fetch = vi.fn((url, opts) => {
+      if (opts && opts.method === 'PUT') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      }
+      if (typeof url === 'string' && url.includes(`/documents/download/${fileId}`)) {
+        return Promise.resolve({
+          ok: true,
+          blob: () => Promise.resolve(new Blob([encWire])),
+          arrayBuffer: () => Promise.resolve(encWire.buffer),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(docResponse) });
+    });
+
+    renderWithProviders(<DocumentEditor />, { route: `/edit/${docId}` });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /unlock/i })).toBeInTheDocument());
+    await user.type(screen.getByPlaceholderText(/password/i), password);
+    await user.click(screen.getByRole('button', { name: /unlock/i }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument());
+
+    // Toggle encryption off without uploading a new file.
+    await user.click(screen.getByLabelText(/keep encrypted with password/i));
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      const putCall = global.fetch.mock.calls.find(c => c[1] && c[1].method === 'PUT');
+      expect(putCall).toBeDefined();
+    });
+
+    const downloadCall = global.fetch.mock.calls.find(
+      c => typeof c[0] === 'string' && c[0].includes(`/documents/download/${fileId}`)
+    );
+    expect(downloadCall).toBeDefined();
+
+    const putCall = global.fetch.mock.calls.find(c => c[1] && c[1].method === 'PUT');
+    const uploadedFile = putCall[1].body.get('file');
+    expect(uploadedFile).toBeInstanceOf(File);
+    expect(uploadedFile.name).toBe('data.bin');
+    const uploadedBytes = new Uint8Array(await uploadedFile.arrayBuffer());
+    expect(Array.from(uploadedBytes)).toEqual(Array.from(plainBytes));
+    // Body content must be plaintext (no DMENC1: prefix) since we toggled off.
+    expect(putCall[1].body.get('content')).toBe('secret body');
+  });
+
+  it('Issue #12: re-uploads encrypted attachment when toggling encryption on for plaintext doc', async () => {
+    const user = userEvent.setup();
+    const { decryptFile } = await import('../crypto');
+
+    const docId = 'sync5678-aaaa-bbbb-cccc-000000000000';
+    const password = 'new-pw';
+    const fileId = `${docId}_notes.txt`;
+    const plainBytes = new Uint8Array([1, 2, 3, 4, 5]);
+    const docResponse = { id: docId, title: 't', content: 'plain body', file_id: fileId };
+
+    global.fetch = vi.fn((url, opts) => {
+      if (opts && opts.method === 'PUT') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      }
+      if (typeof url === 'string' && url.includes(`/documents/download/${fileId}`)) {
+        return Promise.resolve({
+          ok: true,
+          blob: () => Promise.resolve(new Blob([plainBytes])),
+          arrayBuffer: () => Promise.resolve(plainBytes.buffer),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(docResponse) });
+    });
+
+    renderWithProviders(<DocumentEditor />, { route: `/edit/${docId}` });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument());
+
+    // Toggle encryption on, fill password, submit.
+    await user.click(screen.getByLabelText(/encrypt with a password/i));
+    await user.type(screen.getByPlaceholderText(/^password$/i), password);
+    await user.type(screen.getByPlaceholderText(/confirm password/i), password);
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      const putCall = global.fetch.mock.calls.find(c => c[1] && c[1].method === 'PUT');
+      expect(putCall).toBeDefined();
+    });
+
+    const putCall = global.fetch.mock.calls.find(c => c[1] && c[1].method === 'PUT');
+    const uploadedFile = putCall[1].body.get('file');
+    expect(uploadedFile).toBeInstanceOf(File);
+    expect(uploadedFile.name).toBe('dmencblob'); // encryptFile renames to sentinel
+    const wire = new Uint8Array(await uploadedFile.arrayBuffer());
+    const { name, bytes } = await decryptFile(password, wire);
+    expect(name).toBe('notes.txt'); // original prefix-stripped name preserved
+    expect(Array.from(bytes)).toEqual(Array.from(plainBytes));
+    // Body must now be encrypted.
+    expect(putCall[1].body.get('content').startsWith('DMENC1:')).toBe(true);
+  });
+
   it('DocumentList marks encrypted docs with a lock badge and hides preview', async () => {
     const { encryptText } = await import('../crypto');
     const envelope = await encryptText('pw', 'should not be visible');

--- a/src/main.rs
+++ b/src/main.rs
@@ -410,6 +410,28 @@ async fn update_document(
                 }),
             )
         })?;
+
+        // Only after the new attachment is safely uploaded, drop any older
+        // attachment blobs for this document so the GET path can no longer
+        // ressuscitare un blob orfano (es. dopo cambio crypto state in #12).
+        if let Some(Ok(blob_list)) = client
+            .container_client
+            .list_blobs()
+            .into_stream()
+            .next()
+            .await
+        {
+            let prefix = format!("{}_", id);
+            for blobfile in blob_list.blobs.blobs() {
+                if blobfile.name.starts_with(&prefix) && blobfile.name != file_name {
+                    let _ = client
+                        .container_client
+                        .blob_client(&blobfile.name)
+                        .delete()
+                        .await;
+                }
+            }
+        }
     }
 
     Ok(Json(Document {


### PR DESCRIPTION
## Summary

Resolves the attachment-encryption drift described in #12, and bundles in
the encrypt/decrypt toggle from #11 (whose commits this branch is built on).

- **Frontend** — `App.jsx` `handleSubmit`: when an existing document has an
  attachment, the user has not uploaded a new file, and the toggle state has
  flipped, the save path now fetches the current attachment, decrypts or
  re-encrypts it client-side, and re-uploads it as part of the same PUT.
- **Backend** — `update_document` (`src/main.rs`): after a successful new
  blob upload, any other blob matching the document's `{id}_*` prefix is
  deleted. This closes a pre-existing latent bug (changing attachment with a
  different filename used to leave orphan blobs) and is the pre-condition
  that makes the client-side sync actually fix #12 in both directions —
  without it the GET path could still resurrect an orphan blob in case A
  (encrypted → plaintext) because Azure returns blobs in lexicographic order
  and `_dmencblob` sorts before most filenames.
- **Frontend** — removed the red "encryption is off but attachment is still
  encrypted" warning that PR #11 added: the sync now actually resolves the
  underlying state, so the warning is no longer needed. The amber "saving
  as plaintext" warning is kept and extended to mention the attachment too.

Supersedes #11 — close it manually with a "Superseded by this PR" comment
after this one merges.

Closes #12.

## Scenarios covered

| Action by user | Doc body after save | Attachment after save | Status |
|---|---|---|---|
| Toggle encryption **off** on an encrypted doc (no new file) | plaintext | decrypted client-side with the unlock password, re-uploaded as `{id}_{originalName}`, old `{id}_dmencblob` deleted | fixed |
| Toggle encryption **on** for a previously plaintext doc (no new file) | encrypted | encrypted client-side with the new password, re-uploaded as `{id}_dmencblob`, old `{id}_{originalName}` deleted | fixed |
| Upload a new file alongside any toggle change | as before | new file encrypted/uploaded as before, old attachment of any name cleaned up by the backend | fixed (also fixes the latent orphan-blob bug) |
| Change-password on an already-encrypted doc | n/a | n/a | not in scope — UI still keeps the password readonly when `isExistingEncrypted`, so this case cannot be triggered yet |

## Test plan

Automated:
- `npm test` — 56/56 passing (54 existing + 2 new: re-upload decrypted /
  re-upload encrypted attachment via the toggle).
- `cargo check` — clean.

Manual (not run by Claude — needs Azure-backed backend):
- [ ] Encrypted doc with encrypted attachment, unlock, toggle off, save →
      attachment downloads as plaintext with original filename; only one
      `{id}_*` blob remains in the container.
- [ ] Plaintext doc with plaintext attachment, toggle on, set password,
      save → attachment is shown as `🔒 Encrypted attachment` and decrypts
      with the chosen password; only one `{id}_*` blob remains.
- [ ] Edit a doc that already has an attachment, upload a different file
      (no toggle change) → only the new blob remains in the container
      (validates the backend cleanup outside of the #12 path).

## Test gaps

- No backend integration tests exist for `update_document` (the binary has
  no `#[cfg(test)]` blocks). The cleanup branch is exercised manually via
  the test plan above. Adding mocked Azure tests would be a separate change.