### PR TITLE
fix(#13): point Vite dev proxy at /api

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,7 +7,7 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
   server: {
     proxy: {
-      '/documents': 'http://localhost:8000'
+      '/api': 'http://localhost:8000'
     }
   },
   plugins: [react(),tailwindcss()],


### PR DESCRIPTION
## Summary

Single-line change in `frontend/vite.config.js`: the dev proxy now forwards
`/api` to `http://localhost:8000` instead of `/documents`, aligning it with
the frontend's `backendUrl` default (`/api`) and Rocket's mount path
(`.mount("/api", ...)`).

Without this, `npm run dev` could not reach the backend without a manual
`VITE_BACKEND_URL` override.

Closes #13.

## Test plan

- [ ] `cargo run` (Rocket on :8000) + `cd frontend && npm run dev` (Vite on :5173)
- [ ] http://localhost:5173 → document list populates from backend
- [ ] Network tab shows `GET /api/documents` → 200 JSON (not 404/HTML)