### PR TITLE
Add glama.json for maintainer claim

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "giuliohome"
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `glama.json` declaring `giuliohome` as the maintainer.
- Required so I can run the **Login with GitHub to claim** flow on `glama.ai/mcp/servers/giuliohome-org/doc-manager` — the repo lives under the `giuliohome-org` org, so Glama needs an explicit mapping to my personal account.
- Schema only defines `maintainers`; everything else (Dockerfile build spec, description, release) is configured via the Glama admin UI after the claim succeeds.

## Why now
Doc Manager was approved and listed on Glama. Claiming the server unlocks Dockerfile config + release, which in turn enable the score badge that removes `missing-glama` on punkpeye/awesome-mcp-servers#6023.

## Test plan
- [ ] Merge, then click *Login with GitHub to claim* on the Glama server page.
- [ ] Upload root `Dockerfile` via Glama admin and confirm checks pass.
- [ ] Create a Glama release and verify score badge renders.
- [ ] Update punkpeye/awesome-mcp-servers#6023 with the badge to drop `missing-glama`.