### PR TITLE
Add MCP stdio transport for mcp-proxy compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ sudo ctr t start doc-manager
 | `OAUTH_ALLOWED_USERS`         | with `OAUTH_PROVIDER`   | Comma-separated GitHub logins; **must list at least one user** — empty refuses to start          |
 | `MCP_READ_ONLY`               | no (default false)      | When `true`/`1`/`yes`, hides create/update MCP tools                                             |
 | `MCP_PUBLIC_INTROSPECT`       | no (auto)               | Opens `/mcp` for unauthenticated `tools/list` only (calls are 403'd) so registries like Glama can probe. Auto-on when both `AZURE_STORAGE_ACCOUNT` and `OAUTH_PROVIDER` are unset; set `0` to force-disable. |
+| `MCP_STDIO`                   | no (default false)      | When `true`/`1`/`yes` (or pass `--stdio`), runs as a stdio MCP server (newline-delimited JSON-RPC on stdin/stdout) instead of starting the HTTP listener. Used by registries that wrap servers with `mcp-proxy`. |
 
 ## End-to-end tests
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -553,6 +553,16 @@ async fn rocket() -> _ {
 
     let azure_client = AzureClient { container_client };
 
+    if mcp::stdio_mode() {
+        match mcp::run_stdio(&azure_client).await {
+            Ok(()) => std::process::exit(0),
+            Err(e) => {
+                eprintln!("MCP stdio mode failed: {e}");
+                std::process::exit(1);
+            }
+        }
+    }
+
     let cors = CorsOptions {
         allowed_origins: AllowedOrigins::some_exact(&[
             //

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -897,3 +897,91 @@ async fn tool_delete_attachment(args: Value, client: &AzureClient) -> Result<Str
     }))
     .map_err(|e| McpError::internal(format!("serialize: {e}")))
 }
+
+// ---------- stdio MCP transport ----------
+//
+// Glama and other registries wrap the server with `mcp-proxy --`, which
+// expects a stdio MCP child (newline-delimited JSON-RPC on stdin/stdout).
+// This loop reuses the same `dispatch()` as the HTTP `/mcp` route so the
+// two surfaces stay in lockstep.
+
+pub fn stdio_mode() -> bool {
+    if std::env::args().skip(1).any(|a| a == "--stdio") {
+        return true;
+    }
+    matches!(
+        env::var("MCP_STDIO").ok().as_deref(),
+        Some("1") | Some("true") | Some("TRUE") | Some("yes")
+    )
+}
+
+pub async fn run_stdio(client: &AzureClient) -> std::io::Result<()> {
+    use rocket::tokio::io::{AsyncBufReadExt, BufReader};
+
+    eprintln!("doc-manager: MCP stdio mode (ndjson on stdin/stdout)");
+
+    let stdin = rocket::tokio::io::stdin();
+    let mut reader = BufReader::new(stdin);
+    let mut stdout = rocket::tokio::io::stdout();
+    let mut buf = String::new();
+
+    loop {
+        buf.clear();
+        let n = reader.read_line(&mut buf).await?;
+        if n == 0 {
+            return Ok(()); // EOF
+        }
+        let line = buf.trim_end_matches(['\n', '\r']);
+        if line.is_empty() {
+            continue;
+        }
+
+        let req: JsonRpcRequest = match serde_json::from_str(line) {
+            Ok(r) => r,
+            Err(e) => {
+                write_line(
+                    &mut stdout,
+                    &json!({
+                        "jsonrpc": "2.0",
+                        "id": Value::Null,
+                        "error": {
+                            "code": -32700,
+                            "message": format!("Parse error: {e}"),
+                        }
+                    }),
+                )
+                .await?;
+                continue;
+            }
+        };
+
+        let id = req.id.clone();
+        let is_notification = id.is_none();
+        let result = dispatch(&req.method, req.params, client).await;
+        if is_notification {
+            continue;
+        }
+        let id = id.unwrap_or(Value::Null);
+        let resp = match result {
+            Ok(v) => json!({"jsonrpc": "2.0", "id": id, "result": v}),
+            Err(e) => json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {"code": e.code, "message": e.message}
+            }),
+        };
+        write_line(&mut stdout, &resp).await?;
+    }
+}
+
+async fn write_line<W>(out: &mut W, v: &Value) -> std::io::Result<()>
+where
+    W: rocket::tokio::io::AsyncWrite + Unpin,
+{
+    use rocket::tokio::io::AsyncWriteExt;
+    let s = serde_json::to_string(v).expect("serialize JSON value");
+    out.write_all(s.as_bytes()).await?;
+    out.write_all(b"\n").await?;
+    out.flush().await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Adds an `MCP_STDIO=1` env var (and `--stdio` CLI flag) that runs the binary as a stdio MCP server (newline-delimited JSON-RPC on stdin/stdout) instead of starting the Rocket HTTP listener.
- Reuses the existing `mcp::dispatch()` so the HTTP `/mcp` route and the new stdio loop stay in lockstep — same `initialize`, `tools/list`, `tools/call` shape, same `public_introspect()` gating for write tools.

## Why
Glama (and any registry that wraps servers with `mcp-proxy --`) expects a **stdio MCP child**: spawn the binary, write JSON-RPC requests to its stdin, read responses from its stdout. Our HTTP-only server makes that introspect check fail at runtime, regardless of how clean the Docker build is.

This unblocks the Glama build/release flow for giuliohome-org/doc-manager and removes the `missing-glama` label from punkpeye/awesome-mcp-servers#6023.

## How to use from a Glama build spec
Keep cmdArguments as-is (Glama auto-prepends `mcp-proxy --`) and add to `placeholderArguments`:
```json
{ MCP_STDIO: 1, MCP_PUBLIC_INTROSPECT: 1, ...dummy required vars }
```

## Test plan
- [x] `cargo check` passes locally (no new warnings).
- [ ] After merge, retry the Glama Build with `MCP_STDIO=1` in placeholderArguments.
- [ ] Verify Glama runtime check completes and a score badge appears.
- [ ] Update PR punkpeye/awesome-mcp-servers#6023 with the badge to drop `missing-glama`.