### PR TITLE
Add Glama card badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Doc Manager
 
+<p align="center">
+  <a href="https://glama.ai/mcp/servers/giuliohome-org/doc-manager">
+    <img alt="doc-manager MCP server on Glama" src="https://glama.ai/mcp/servers/giuliohome-org/doc-manager/badges/card.svg" />
+  </a>
+</p>
+
 A zero-knowledge document vault backed by Azure Blob Storage, with a built-in
 **MCP server** so you can add, read and search your docs straight from a
 Claude conversation.


### PR DESCRIPTION
## Summary
Glama lists `giuliohome-org/doc-manager` at https://glama.ai/mcp/servers/giuliohome-org/doc-manager with a passing build test, so surface the badge near the top of the README.

Uses the **card** badge (visual card with score) rather than the smaller `score.svg` because there is only one badge here — a single score icon would look orphaned, the card carries enough context to stand alone.

## Test plan
- [ ] Open README on GitHub; verify the badge renders, links to the Glama page, and the score image loads.