### PR TITLE
Ignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 k8s/secret.yaml
 chat/
 target/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.local.json` to `.gitignore`. It's the per-machine Claude Code permissions file and shouldn't be shared across contributors.
- Scoped to just that file (not the whole `.claude/` directory) so a future team-wide `.claude/settings.json` can still be committed.

## Test plan
- [x] `git status` no longer reports `.claude/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)